### PR TITLE
replace last two /sbin occurences with $(DIR)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,7 +30,7 @@ install: all
 	$(MKDIR) $(DESTDIR)$(DIR)
 	$(CP) $(BIN) $(DESTDIR)$(DIR)
 	$(CHMOD) 755 $(DESTDIR)$(DIR)/$(BIN)*
-	ln -s $(BIN) $(DESTDIR)/sbin/rxadm
+	ln -s $(BIN) $(DESTDIR)$(DIR)/rxadm
 
 .PHONY: nocrypt-install
 nocrypt-install: nocrypt
@@ -38,7 +38,7 @@ nocrypt-install: nocrypt
 	$(MKDIR) $(DESTDIR)$(DIR)
 	$(CP) $(BIN) $(DESTDIR)$(DIR)
 	$(CHMOD) 755 $(DESTDIR)$(DIR)/$(BIN)*
-	ln -s $(BIN) $(DESTDIR)/sbin/rxadm
+	ln -s $(BIN) $(DESTDIR)$(DIR)/rxadm
 
 .PHONY: uninstall
 uninstall:


### PR DESCRIPTION
This change looks straight forward but I wonder if the symbolic link of
`rxadm` pointing to `rapiddisk` is still required.
I guess the `rxadm` occurrences could be deleted from the makefile without
any effects as I could not detect any references from within the code.