### PR TITLE
GPLv2+ headers for /src

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,3 +1,21 @@
+# Copyright © 2011-2016 Petros Koutoupis
+# All rights reserved.
+#
+# This file is part of RapidDisk.
+#
+# RapidDisk is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# RapidDisk is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RapidDisk.  If not, see <http://www.gnu.org/licenses/>.
+
 ifeq ($(CC),)
 	CC := gcc -Werror
 endif

--- a/src/archive.c
+++ b/src/archive.c
@@ -1,6 +1,21 @@
 /*********************************************************************************
- ** Copyright (c) 2011-2016 Petros Koutoupis
+ ** Copyright © 2011-2016 Petros Koutoupis
  ** All rights reserved.
+ **
+ ** This file is part of RapidDisk.
+ **
+ ** RapidDisk is free software: you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License as published by
+ ** the Free Software Foundation, either version 2 of the License, or
+ ** (at your option) any later version.
+ **
+ ** RapidDisk is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ ** GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU General Public License
+ ** along with RapidDisk.  If not, see <http://www.gnu.org/licenses/>.
  **
  ** @project: rapiddisk
  **

--- a/src/common.h
+++ b/src/common.h
@@ -1,6 +1,21 @@
 /*********************************************************************************
- ** Copyright (c) 2011-2016 Petros Koutoupis
+ ** Copyright © 2011-2016 Petros Koutoupis
  ** All rights reserved.
+ **
+ ** This file is part of RapidDisk.
+ **
+ ** RapidDisk is free software: you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License as published by
+ ** the Free Software Foundation, either version 2 of the License, or
+ ** (at your option) any later version.
+ **
+ ** RapidDisk is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ ** GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU General Public License
+ ** along with RapidDisk.  If not, see <http://www.gnu.org/licenses/>.
  **
  ** @project: rapiddisk
  **

--- a/src/core.c
+++ b/src/core.c
@@ -1,6 +1,21 @@
 /*********************************************************************************
- ** Copyright (c) 2011-2016 Petros Koutoupis
+ ** Copyright © 2011-2016 Petros Koutoupis
  ** All rights reserved.
+ **
+ ** This file is part of RapidDisk.
+ **
+ ** RapidDisk is free software: you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License as published by
+ ** the Free Software Foundation, either version 2 of the License, or
+ ** (at your option) any later version.
+ **
+ ** RapidDisk is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ ** GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU General Public License
+ ** along with RapidDisk.  If not, see <http://www.gnu.org/licenses/>.
  **
  ** @project: rapiddisk
  **

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -1,6 +1,21 @@
 /*********************************************************************************
- ** Copyright (c) 2011-2016 Petros Koutoupis
+ ** Copyright © 2011-2016 Petros Koutoupis
  ** All rights reserved.
+ **
+ ** This file is part of RapidDisk.
+ **
+ ** RapidDisk is free software: you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License as published by
+ ** the Free Software Foundation, either version 2 of the License, or
+ ** (at your option) any later version.
+ **
+ ** RapidDisk is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ ** GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU General Public License
+ ** along with RapidDisk.  If not, see <http://www.gnu.org/licenses/>.
  **
  ** @project: rapiddisk
  **

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,21 @@
 /*********************************************************************************
- ** Copyright (c) 2011-2016 Petros Koutoupis
+ ** Copyright © 2011-2016 Petros Koutoupis
  ** All rights reserved.
+ **
+ ** This file is part of RapidDisk.
+ **
+ ** RapidDisk is free software: you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License as published by
+ ** the Free Software Foundation, either version 2 of the License, or
+ ** (at your option) any later version.
+ **
+ ** RapidDisk is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ ** GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU General Public License
+ ** along with RapidDisk.  If not, see <http://www.gnu.org/licenses/>.
  **
  ** @project: rapiddisk
  **


### PR DESCRIPTION
I left it as GPLv2+.  You can change it if you want strict GPLv2