### PR TITLE
GPLv2 headers for /module, based on language from Facebook/flashcache_wt

### DIFF
--- a/module/Makefile
+++ b/module/Makefile
@@ -1,3 +1,18 @@
+# Copyright © 2011-2016 Petros Koutoupis
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; under version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 VERSION = 4.4
 
 ifeq ($(KSRC),)

--- a/module/rapiddisk-cache.c
+++ b/module/rapiddisk-cache.c
@@ -1,6 +1,18 @@
 /*******************************************************************************
- ** Copyright (c) 2011-2016 Petros Koutoupis
+ ** Copyright © 2011-2016 Petros Koutoupis
  ** All rights reserved.
+ **
+ ** This program is free software: you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License as published by
+ ** the Free Software Foundation; under version 2 of the License.
+ **
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ ** GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU General Public License
+ ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
  **
  ** filename: rapiddisk-cache.c
  ** description: Device mapper target for block-level disk write-through and
@@ -13,8 +25,6 @@
  **	  Author: Ming Zhao (mingzhao@ufl.edu)
  **
  ** created: 3Dec11, petros@petroskoutoupis.com
- **
- ** This file is licensed under GPLv2.
  **
  ******************************************************************************/
 

--- a/module/rapiddisk.c
+++ b/module/rapiddisk.c
@@ -1,13 +1,23 @@
 /*******************************************************************************
- ** Copyright (c) 2011-2016 Petros Koutoupis
+ ** Copyright © 2011-2016 Petros Koutoupis
  ** All rights reserved.
+ **
+ ** This program is free software: you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License as published by
+ ** the Free Software Foundation; under version 2 of the License.
+ **
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ ** GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU General Public License
+ ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
  **
  ** filename: rapiddisk.c
  ** description: RapidDisk is an enhanced Linux RAM disk module to dynamically
  **	 create, remove, and resize non-persistent RAM drives.
  ** created: 1Jun11, petros@petroskoutoupis.com
- **
- ** This file is licensed under GPLv2.
  **
  ******************************************************************************/
 


### PR DESCRIPTION
Left both modules as GPLv2 strict.  Used language from Facebook/flashcache_wt.