### PR TITLE
Changed the way dkms is installed/removed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,13 @@ uninstall:
 clean:
 	for i in $(SUBDIRS); do cd $$i; make clean; cd ..; done
 
-.PHONY: dkms
-dkms:
-	cd module; make dkms; cd ..
+.PHONY: dkms-install
+dkms-install:
+	cd module; make dkms-install; cd ..
+
+.PHONY: dkms-uninstall
+dkms-uninstall:
+	cd module; make dkms-uninstall; cd ..
 
 .PHONY: tools-install
 tools-install:

--- a/module/Makefile
+++ b/module/Makefile
@@ -50,7 +50,7 @@ clean:
 
 dkms-install:
 ifeq ($(shell dkms status rapiddisk/$(VERSION) -k $(KVER) | grep '$(KVER)' >/dev/null && echo 0 || echo 1 ),0)
-	$(error rapiddisk version $(VERSION) is already installed for kernel $(KVER). Use 'make dkms-remove' first.)
+	$(error rapiddisk version $(VERSION) is already installed for kernel $(KVER). Use 'make dkms-uninstall' first.)
 else
 	dkms install rapiddisk/$(VERSION) -k $(KVER) .
 endif

--- a/module/Makefile
+++ b/module/Makefile
@@ -53,7 +53,7 @@ clean:
 
 dkms-install:
 ifeq ($(shell dkms status rapiddisk/$(VERSION) -k $(KVER) | grep '$(KVER)' >/dev/null && echo 0 || echo 1 ),0)
-	$(error rapiddisk version $(VERSION) is already installed for kernel $(KVER). Use 'make dkms-remove' first.)
+	$(error rapiddisk version $(VERSION) is already installed for kernel $(KVER). Use 'make dkms-uninstall' first.)
 else
 	[ ! -d $(DKMSDEST) ] && $(MKDIR) $(DKMSDEST) || true
 	$(CP) $(DKMSFILES) $(DKMSDEST)

--- a/module/Makefile
+++ b/module/Makefile
@@ -48,10 +48,17 @@ clean:
 	rm -rf *.o *.ko *.symvers *.mod.c .*.cmd Module.markers modules.order *.o.*
 	rm -rf .tmp_versions .rapiddisk.o.d *.unsigned *.sdtinfo.c .ctf/ .cache.mk
 
-.PHONY: dkms
-dkms:
-	sudo mkdir -pv /usr/src/rapiddisk-$(VERSION)/
-	sudo cp -v * /usr/src/rapiddisk-$(VERSION)/
-	sudo dkms add -m rapiddisk -v $(VERSION)
-	sudo dkms build -m rapiddisk -v $(VERSION)
-	sudo dkms install -m rapiddisk -v $(VERSION)
+dkms-install:
+ifeq ($(shell dkms status rapiddisk/$(VERSION) -k $(KVER) | grep '$(KVER)' >/dev/null && echo 0 || echo 1 ),0)
+	$(error rapiddisk version $(VERSION) is already installed for kernel $(KVER). Use 'make dkms-remove' first.)
+else
+	dkms install rapiddisk/$(VERSION) -k $(KVER) .
+endif
+
+dkms-uninstall:
+ifeq ($(shell dkms status rapiddisk/$(VERSION) -k $(KVER) | grep '$(KVER)' >/dev/null && echo 0 || echo 1 ),0)
+	dkms remove rapiddisk/$(VERSION) -k $(KVER)
+else
+	$(error rapiddisk version $(VERSION) is not installed for kernel $(KVER).)
+endif
+

--- a/module/Makefile
+++ b/module/Makefile
@@ -26,6 +26,9 @@ ifeq ($(KVER),)
 endif
 
 MKDIR := mkdir -pv
+CP := cp -v
+DKMSFILES := $(shell ls *.c) dkms.conf Makefile
+DKMSDEST := /usr/src/rapiddisk-$(VERSION)
 
 obj-m += rapiddisk.o
 obj-m += rapiddisk-cache.o
@@ -50,8 +53,10 @@ clean:
 
 dkms-install:
 ifeq ($(shell dkms status rapiddisk/$(VERSION) -k $(KVER) | grep '$(KVER)' >/dev/null && echo 0 || echo 1 ),0)
-	$(error rapiddisk version $(VERSION) is already installed for kernel $(KVER). Use 'make dkms-uninstall' first.)
+	$(error rapiddisk version $(VERSION) is already installed for kernel $(KVER). Use 'make dkms-remove' first.)
 else
+	[ ! -d $(DKMSDEST) ] && $(MKDIR) $(DKMSDEST) || true
+	$(CP) $(DKMSFILES) $(DKMSDEST)
 	dkms install rapiddisk/$(VERSION) -k $(KVER) .
 endif
 


### PR DESCRIPTION
#36 During "make dkms" remove older DKMS installs on current kernel

Now `dkms-install` target is used to check if current rapiddisk version is already installed on current kernel. `dkms-uninstall` uninstalls rapiddisk via dkms (this version from this kernel only)