### PR TITLE
Really small changes to module/Makefile

### DIFF
--- a/module/Makefile
+++ b/module/Makefile
@@ -52,25 +52,21 @@ clean:
 	rm -rf .tmp_versions .rapiddisk.o.d *.unsigned *.sdtinfo.c .ctf/ .cache.mk
 
 dkms-install:
-ifeq ($(shell which dkms 1>&2 2>/dev/null; echo $$?),1)
-	$(error "No dkms.")
-else
-ifeq ($(shell dkms status rapiddisk/$(VERSION) -k $(KVER) | grep '$(KVER)' >/dev/null && echo 0 || echo 1 ),0)
-	$(error rapiddisk version $(VERSION) is already installed for kernel $(KVER). Use 'make dkms-uninstall' first.)
+ifeq ($(shell which dkms >/dev/null 2>/dev/null; echo $$?),1)
+	$(error No 'dkms' command found)
+else ifeq ($(shell dkms status rapiddisk/$(VERSION) -k $(KVER) | grep '$(KVER)' >/dev/null 2>/dev/null; echo $$?),0)
+	$(error rapiddisk version $(VERSION) is already installed for kernel $(KVER). Use 'make dkms-uninstall' first)
 else
 	[ ! -d $(DKMSDEST) ] && $(MKDIR) $(DKMSDEST) || true
 	$(CP) $(DKMSFILES) $(DKMSDEST)
 	dkms install rapiddisk/$(VERSION) -k $(KVER) .
 endif
-endif
 
 dkms-uninstall:
-ifeq ($(shell which dkms 1>&2 2>/dev/null; echo $$?),1)
-	$(error "No dkms.")
-else
-ifeq ($(shell dkms status rapiddisk/$(VERSION) -k $(KVER) | grep '$(KVER)' >/dev/null && echo 0 || echo 1 ),0)
+ifeq ($(shell which dkms >/dev/null 2>/dev/null; echo $$?),1)
+	$(error No 'dkms' command found)
+else ifeq ($(shell dkms status rapiddisk/$(VERSION) -k $(KVER) | grep '$(KVER)' >/dev/null 2>/dev/null; echo $$?),0)
 	dkms remove rapiddisk/$(VERSION) -k $(KVER)
 else
-	$(error rapiddisk version $(VERSION) is not installed for kernel $(KVER).)
-endif
+	$(error rapiddisk version $(VERSION) is not installed for kernel $(KVER))
 endif


### PR DESCRIPTION
Changed the if/else/endif syntax and made some error messages nicer

I changed the `1>&2 2>/dev/null` syntax cause not working well on Ubuntu.
Changed the if/else/endif chains to a cleaner syntax.
Switched to `echo $$?` to check the return code, it is simpler and works well.
I removed `"..."` and final `.` from error messages. The `.` is added by Make.

These changes should be tested on Centos though.

And are really small things!

Bye!