### PR TITLE
Compilation fix for linux kernels >=5.11

### DIFF
--- a/module/rapiddisk-cache.c
+++ b/module/rapiddisk-cache.c
@@ -38,18 +38,13 @@
 #include <linux/bio.h>
 #include <linux/vmalloc.h>
 #include <linux/slab.h>
-#include <linux/hash.h>
 #include <linux/spinlock.h>
 #include <linux/workqueue.h>
-#include <linux/pagemap.h>
-#include <linux/random.h>
 #include <linux/version.h>
 #include <linux/seq_file.h>
 #include <linux/hardirq.h>
-#include <asm/kmap_types.h>
 #include <linux/dm-io.h>
 #include <linux/device-mapper.h>
-#include <linux/bio.h>
 
 #define ASSERT(x) do { \
 	if (unlikely(!(x))) { \

--- a/src/net.c
+++ b/src/net.c
@@ -31,7 +31,6 @@
 #include "daemon.h"
 #include <jansson.h>
 #include <sys/socket.h>
-#include <linux/version.h>
 #include <microhttpd.h>
 
 bool verbose;


### PR DESCRIPTION
This patch contains
* c23cff7 resolves compilation error for linux kernels >=5.11 (obsoleted `#include <asm/kmap_types.h>`)

I successfully tested on ArchLinux with kernels 5.10.x and 5.11.x
`==> dkms install --no-depmod -m rapiddisk -v 7.1.0 -k 5.11.2-arch1-1`
`==> dkms install --no-depmod -m rapiddisk -v 7.1.0 -k 5.10.19-1-lts`

I hope it doesn't break older kernel compilations :)
