### PR TITLE
corrected return type of MHD_Callback (warning fix)

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -41,7 +41,7 @@ unsigned char path[NAMELEN] = {0};
  * The responses to our GET requests. Although, we are not SPECIFICALLY checking that they are GETs.
  * We are just check the URL and the string command.
  */
-static int answer_to_connection(void *cls, struct MHD_Connection *connection, const char *url,
+static enum MHD_Result answer_to_connection(void *cls, struct MHD_Connection *connection, const char *url,
                                 const char *method, const char *version, const char *upload_data,
                                  size_t *upload_data_size, void **con_cls)
 {


### PR DESCRIPTION
This patch contains
* e4599ba resolves a compiler warning due to callback return type mismatch (`enum MHD_Result`)

I successfully tested on ArchLinux with kernels 5.10.x and 5.11.x
`==> dkms install --no-depmod -m rapiddisk -v 7.1.0 -k 5.11.2-arch1-1`
`==> dkms install --no-depmod -m rapiddisk -v 7.1.0 -k 5.10.19-1-lts`

I hope it doesn't break older kernel compilations :)
