### PR TITLE
Feature/support newer libmicrohttpd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Release 7.2.1 ###
+
+- module: Added support for RHEL 8.4 kernel
+- utility: Added support for libmicrohttpd v0.9.71 and newer while still supporting legacy versions
+
 ### Release 7.2.0 ###
 
 - module: Updated for 5.12 kernels and later (thank you Michael)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+rapiddisk (7.2.1-1) released; urgency=medium
+
+* module: Added support for RHEL 8.4 kernel
+* utility: added support for libmicrohttpd v0.9.71 and newer while still supporting legacy versions
+
 rapiddisk (7.2.0-1) released; urgency=medium
 
 * module: Updated for 5.12 kernels and later (thank you Michael)

--- a/debian/control
+++ b/debian/control
@@ -1,5 +1,5 @@
 Package: rapiddisk
-Version: 7.2.0-1
+Version: 7.2.1-1
 Section: base
 Priority: optional
 Architecture: amd64

--- a/debian/postinst
+++ b/debian/postinst
@@ -16,9 +16,9 @@ fi
 case "$1" in
 
   configure)
-    dkms add -m rapiddisk -v 7.2.0
-    dkms build -m rapiddisk -v 7.2.0
-    dkms install -m rapiddisk -v 7.2.0
+    dkms add -m rapiddisk -v 7.2.1
+    dkms build -m rapiddisk -v 7.2.1
+    dkms install -m rapiddisk -v 7.2.1
     echo "rapiddisk max_sectors=2048 nr_requests=1024" >> /etc/modules
     echo "rapiddisk-cache" >> /etc/modules
     echo "dm_mod" >> /etc/modules

--- a/debian/prerm
+++ b/debian/prerm
@@ -14,7 +14,7 @@ fi
 
 case "$1" in
   remove|upgrade|deconfigure)
-    dkms remove -m rapiddisk -v 7.2.0 --all
+    dkms remove -m rapiddisk -v 7.2.1 --all
   ;;
 
   failed-upgrade)

--- a/misc/rapiddisk-legacy/rapiddisk-legacy.sh
+++ b/misc/rapiddisk-legacy/rapiddisk-legacy.sh
@@ -8,7 +8,7 @@ fi
 ## usage ##
 function help_menu()
 {
-	echo -e "$1 7.2.0"
+	echo -e "$1 7.2.1"
 	echo -e "Copyright 2011 - 2021 Petros Koutoupis"
 	echo -e ""
 	echo -e "$1 is an administration tool to manage the RapidDisk RAM disk devices and"

--- a/module/Makefile
+++ b/module/Makefile
@@ -15,7 +15,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-VERSION = 7.2.0
+VERSION = 7.2.1
 
 ifeq ($(KSRC),)
 	KSRC := /lib/modules/$(shell uname -r)/build

--- a/module/dkms.conf
+++ b/module/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="rapiddisk"
-PACKAGE_VERSION="7.2.0"
+PACKAGE_VERSION="7.2.1"
 BUILT_MODULE_NAME[0]="rapiddisk"
 BUILT_MODULE_NAME[1]="rapiddisk-cache"
 DEST_MODULE_LOCATION[0]="/kernel/rapiddisk/"

--- a/module/rapiddisk-cache.c
+++ b/module/rapiddisk-cache.c
@@ -54,7 +54,7 @@
 	} \
 } while (0)
 
-#define VERSION_STR	"7.2.0"
+#define VERSION_STR	"7.2.1"
 #define DM_MSG_PREFIX	"rapiddisk-cache"
 
 #define READCACHE	1
@@ -1234,7 +1234,7 @@ cache_status(struct dm_target *ti, status_type_t type, unsigned status_flags,
 
 static struct target_type cache_target = {
 	.name    = "rapiddisk-cache",
-	.version = {7, 2, 0},
+	.version = {7, 2, 1},
 	.module  = THIS_MODULE,
 	.ctr	 = cache_ctr,
 	.dtr	 = cache_dtr,

--- a/module/rapiddisk.c
+++ b/module/rapiddisk.c
@@ -41,7 +41,7 @@
 #include <linux/radix-tree.h>
 #include <linux/io.h>
 
-#define VERSION_STR		"7.2.0"
+#define VERSION_STR		"7.2.1"
 #define PREFIX			"rapiddisk"
 #define BYTES_PER_SECTOR	512
 #define MAX_RDSKS		128
@@ -637,7 +637,7 @@ static int rdsk_ioctl(struct block_device *bdev, fmode_t mode,
 		error = -EBUSY;
 		if (bdev->bd_openers <= 1) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,3,0)
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0) || (defined(RHEL_MAJOR) && RHEL_MAJOR == 8 && RHEL_MINOR >= 4)
 			invalidate_bdev(bdev);
 #else
 			kill_bdev(bdev);

--- a/rapiddisk.spec.rhel
+++ b/rapiddisk.spec.rhel
@@ -1,6 +1,6 @@
 Summary: The RapidDisk software defined advanced RAM drive and storage caching solution.
 Name: rapiddisk
-Version: 7.2.0
+Version: 7.2.1
 Release: 1
 License: General Public License Version 2
 Group: Applications/System
@@ -78,6 +78,9 @@ rm -rf %{buildroot}
 %doc %attr(0444,root,root) /usr/share/man/man1/*
 
 %changelog
+* Sun Jun 13 2021 Petros Koutoupis <petros@petroskoutoupis.com>
+- module: Added support for RHEL 8.4 kernel
+- utility: added support for libmicrohttpd v0.9.71 and newer while still supporting legacy versions
 * Fri May 28 2021 Petros Koutoupis <petros@petroskoutoupis.com>
 - module: Updated for 5.12 kernels and later (thank you Michael)
 - utility: remove unused headers (thank you Marcel Huber)

--- a/rapiddisk.spec.sles
+++ b/rapiddisk.spec.sles
@@ -1,6 +1,6 @@
 Summary: The RapidDisk software defined advanced RAM drive and storage caching solution.
 Name: rapiddisk
-Version: 7.2.0
+Version: 7.2.1
 Release: 1
 License: General Public License Version 2
 Group: Applications/System
@@ -79,6 +79,9 @@ rm -rf %{buildroot}
 %doc %attr(0444,root,root) /usr/share/man/man1/*
 
 %changelog
+* Sun Jun 13 2021 Petros Koutoupis <petros@petroskoutoupis.com>
+- module: Added support for RHEL 8.4 kernel
+- utility: added support for libmicrohttpd v0.9.71 and newer while still supporting legacy versions
 * Fri May 28 2021 Petros Koutoupis <petros@petroskoutoupis.com>
 - module: Updated for 5.12 kernels and later (thank you Michael)
 - utility: remove unused headers (thank you Marcel Huber)

--- a/src/Makefile
+++ b/src/Makefile
@@ -53,7 +53,11 @@ json-server.o: json.c
 	$(CC) -c json.c -DSERVER -o json-server.o
 
 net.o: net.c
+ifeq ($(shell grep -q "enum MHD_Result" $(DESTDIR)/usr/include/microhttpd.h; echo $$?),1)
+	$(CC) -c net.c -DLEGACY -o net.o
+else
 	$(CC) -c net.c -o net.o
+endif
 
 rdsk.o: rdsk.c
 	$(CC) -c rdsk.c -o rdsk.o

--- a/src/common.h
+++ b/src/common.h
@@ -44,7 +44,7 @@
 #define PROCESS			"rapiddisk"
 #define DAEMON			PROCESS "d"
 #define COPYRIGHT		"Copyright 2011 - 2021 Petros Koutoupis"
-#define VERSION_NUM	  	"7.2.0"
+#define VERSION_NUM	  	"7.2.1"
 #define SUCCESS			0
 #define INVALID_VALUE		-1
 #define NAMELEN			0x200

--- a/src/net.c
+++ b/src/net.c
@@ -40,7 +40,11 @@ unsigned char path[NAMELEN] = {0};
  * The responses to our GET requests. Although, we are not SPECIFICALLY checking that they are GETs.
  * We are just check the URL and the string command.
  */
+#if !defined LEGACY
+static enum MHD_Result answer_to_connection(void *cls, struct MHD_Connection *connection, const char *url,
+#else
 static int answer_to_connection(void *cls, struct MHD_Connection *connection, const char *url,
+#endif
                                 const char *method, const char *version, const char *upload_data,
                                  size_t *upload_data_size, void **con_cls)
 {
@@ -54,7 +58,11 @@ static int answer_to_connection(void *cls, struct MHD_Connection *connection, co
 	unsigned char *page = (unsigned char *)calloc(1, BUFSZ);
 	if (page == NULL) {
 		printf("%s: %s: calloc: %s\n", DAEMON, __func__, strerror(errno));
+#if !defined LEGACY
+		return MHD_NO;
+#else
 		return INVALID_VALUE;
+#endif
 	}
 
 	if (strcmp(method, "GET") == SUCCESS) {


### PR DESCRIPTION
- module: Added support for RHEL 8.4 kernel
- utility: Added support for libmicrohttpd v0.9.71 and newer while still supporting legacy versions