### PR TITLE
Feature/expand writeback stats

### DIFF
--- a/src/cli.h
+++ b/src/cli.h
@@ -103,6 +103,17 @@ typedef struct WC_STATS {
 	unsigned int num_blocks;
 	unsigned int num_free_blocks;
 	unsigned int num_wb_blocks;
+	/* For 5.15 and later */
+	unsigned int num_read_req;
+	unsigned int num_read_cache_hits;
+	unsigned int num_write_req;
+	unsigned int num_write_uncommitted_blk_hits;
+	unsigned int num_write_committed_blk_hits;
+	unsigned int num_write_cache_bypass;
+	unsigned int num_write_cache_alloc;
+	unsigned int num_write_freelist_blocked;
+	unsigned int num_flush_req;
+	unsigned int num_discard_req;
 } WC_STATS;
 
 typedef struct MEM_PROFILE {

--- a/src/cli.h
+++ b/src/cli.h
@@ -99,6 +99,7 @@ typedef struct RC_STATS {
 
 typedef struct WC_STATS {
 	unsigned char device[NAMELEN];
+	bool expanded;
 	int errors;
 	unsigned int num_blocks;
 	unsigned int num_free_blocks;

--- a/src/json.c
+++ b/src/json.c
@@ -290,16 +290,18 @@ int json_cache_wb_statistics(struct WC_STATS *stats)
 		json_object_set_new(object, "num_blocks", json_integer(stats->num_blocks));
 		json_object_set_new(object, "num_free_blocks", json_integer(stats->num_free_blocks));
 		json_object_set_new(object, "num_wb_blocks", json_integer(stats->num_wb_blocks));
-		json_object_set_new(object, "num_read_req", json_integer(stats->num_read_req));
-		json_object_set_new(object, "num_read_cache_hits", json_integer(stats->num_read_cache_hits));
-		json_object_set_new(object, "num_write_req", json_integer(stats->num_write_req));
-		json_object_set_new(object, "num_write_uncommitted_blk_hits", json_integer(stats->num_write_uncommitted_blk_hits));
-		json_object_set_new(object, "num_write_committed_blk_hits", json_integer(stats->num_write_committed_blk_hits));
-		json_object_set_new(object, "num_write_cache_bypass", json_integer(stats->num_write_cache_bypass));
-		json_object_set_new(object, "num_write_cache_alloc", json_integer(stats->num_write_cache_alloc));
-		json_object_set_new(object, "num_write_freelist_blocked", json_integer(stats->num_write_freelist_blocked));
-		json_object_set_new(object, "num_flush_req", json_integer(stats->num_flush_req));
-		json_object_set_new(object, "num_discard_req", json_integer(stats->num_discard_req));
+		if (stats->expanded == TRUE) {
+			json_object_set_new(object, "num_read_req", json_integer(stats->num_read_req));
+			json_object_set_new(object, "num_read_cache_hits", json_integer(stats->num_read_cache_hits));
+			json_object_set_new(object, "num_write_req", json_integer(stats->num_write_req));
+			json_object_set_new(object, "num_write_uncommitted_blk_hits", json_integer(stats->num_write_uncommitted_blk_hits));
+			json_object_set_new(object, "num_write_committed_blk_hits", json_integer(stats->num_write_committed_blk_hits));
+			json_object_set_new(object, "num_write_cache_bypass", json_integer(stats->num_write_cache_bypass));
+			json_object_set_new(object, "num_write_cache_alloc", json_integer(stats->num_write_cache_alloc));
+			json_object_set_new(object, "num_write_freelist_blocked", json_integer(stats->num_write_freelist_blocked));
+			json_object_set_new(object, "num_flush_req", json_integer(stats->num_flush_req));
+			json_object_set_new(object, "num_discard_req", json_integer(stats->num_discard_req));
+		}
 		json_array_append_new(stats_array, object);
 	}
 	json_object_set_new(stats_object, "cache_stats", stats_array);

--- a/src/json.c
+++ b/src/json.c
@@ -290,6 +290,16 @@ int json_cache_wb_statistics(struct WC_STATS *stats)
 		json_object_set_new(object, "num_blocks", json_integer(stats->num_blocks));
 		json_object_set_new(object, "num_free_blocks", json_integer(stats->num_free_blocks));
 		json_object_set_new(object, "num_wb_blocks", json_integer(stats->num_wb_blocks));
+		json_object_set_new(object, "num_read_req", json_integer(stats->num_read_req));
+		json_object_set_new(object, "num_read_cache_hits", json_integer(stats->num_read_cache_hits));
+		json_object_set_new(object, "num_write_req", json_integer(stats->num_write_req));
+		json_object_set_new(object, "num_write_uncommitted_blk_hits", json_integer(stats->num_write_uncommitted_blk_hits));
+		json_object_set_new(object, "num_write_committed_blk_hits", json_integer(stats->num_write_committed_blk_hits));
+		json_object_set_new(object, "num_write_cache_bypass", json_integer(stats->num_write_cache_bypass));
+		json_object_set_new(object, "num_write_cache_alloc", json_integer(stats->num_write_cache_alloc));
+		json_object_set_new(object, "num_write_freelist_blocked", json_integer(stats->num_write_freelist_blocked));
+		json_object_set_new(object, "num_flush_req", json_integer(stats->num_flush_req));
+		json_object_set_new(object, "num_discard_req", json_integer(stats->num_discard_req));
 		json_array_append_new(stats_array, object);
 	}
 	json_object_set_new(stats_object, "cache_stats", stats_array);

--- a/src/rdsk.c
+++ b/src/rdsk.c
@@ -320,6 +320,7 @@ int cache_wb_device_stat_json(struct RC_PROFILE *rc_prof, unsigned char *cache)
 	}
 
 	sprintf(stats->device, "%s", cache);
+	stats->expanded = FALSE;
 	dup = strdup(buf);
 
 	token = strtok((char *)dup, " ");
@@ -335,6 +336,7 @@ int cache_wb_device_stat_json(struct RC_PROFILE *rc_prof, unsigned char *cache)
 	stats->num_wb_blocks = atoi(token);
 	token = strtok(NULL, " ");     /* num read requests */
 	if (!token) goto abort_stat_collect;
+	stats->expanded = TRUE;
 	stats->num_read_req = atoi(token);
 	token = strtok(NULL, " ");     /* num read cache hits */
 	if (!token) goto abort_stat_collect;

--- a/src/rdsk.c
+++ b/src/rdsk.c
@@ -333,6 +333,38 @@ int cache_wb_device_stat_json(struct RC_PROFILE *rc_prof, unsigned char *cache)
 	stats->num_free_blocks = atoi(token);
 	token = strtok(NULL, " ");     /* num wb blocks */
 	stats->num_wb_blocks = atoi(token);
+	token = strtok(NULL, " ");     /* num read requests */
+	if (!token) goto abort_stat_collect;
+	stats->num_read_req = atoi(token);
+	token = strtok(NULL, " ");     /* num read cache hits */
+	if (!token) goto abort_stat_collect;
+	stats->num_read_cache_hits = atoi(token);
+	token = strtok(NULL, " ");     /* num write requests */
+	if (!token) goto abort_stat_collect;
+	stats->num_write_req = atoi(token);
+	token = strtok(NULL, " ");     /* num write uncommitted block hits */
+	if (!token) goto abort_stat_collect;
+	stats->num_write_uncommitted_blk_hits = atoi(token);
+	token = strtok(NULL, " ");     /* num write committed block hits */
+	if (!token) goto abort_stat_collect;
+	stats->num_write_committed_blk_hits = atoi(token);
+	token = strtok(NULL, " ");     /* num write cache bypassed */
+	if (!token) goto abort_stat_collect;
+	stats->num_write_cache_bypass = atoi(token);
+	token = strtok(NULL, " ");     /* num write cache allocated */
+	if (!token) goto abort_stat_collect;
+	stats->num_write_cache_alloc = atoi(token);
+	token = strtok(NULL, " ");     /* num writes blocked on freelist */
+	if (!token) goto abort_stat_collect;
+	stats->num_write_freelist_blocked = atoi(token);
+	token = strtok(NULL, " ");     /* num flush requests */
+	if (!token) goto abort_stat_collect;
+	stats->num_flush_req = atoi(token);
+	token = strtok(NULL, " ");     /* num discard requests */
+	if (!token) goto abort_stat_collect;
+	stats->num_discard_req = atoi(token);
+
+abort_stat_collect:
 
 	rc = json_cache_wb_statistics(stats);
 


### PR DESCRIPTION
The Linux 5.15 kernel has expanded its dm-writecache stats. Adding support to parse.