### PR TITLE
Ubuntu 18 fix and minor improvements

### DIFF
--- a/scripts/rapiddisk-rootdev/CHANGELOG.md
+++ b/scripts/rapiddisk-rootdev/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### Version 0.1.1
+
+Released 2022-03-02
+
+* Fixed issue in boot script under Ubuntu 18 and earlier
+* Improved global uninstall under Ubuntu
+
 ### Version 0.1.0
 
 Released 2021-12-12

--- a/scripts/rapiddisk-rootdev/ubuntu/rapiddisk_boot
+++ b/scripts/rapiddisk-rootdev/ubuntu/rapiddisk_boot
@@ -15,8 +15,8 @@ esac
 . /scripts/functions
 
 # Begin real processing below this line
-if [ -x /usr/sbin/rapiddisk_sub ] ; then
-	/usr/sbin/rapiddisk_sub
+if [ -x /sbin/rapiddisk_sub ] ; then
+	/sbin/rapiddisk_sub
 fi
 
 exit 0


### PR DESCRIPTION
Under Ubuntu, the boot script tried to run `/usr/sbin/rapiddisk_sub` to initialize rapiddisk, but the hook script installs `rapiddisk_sub` in `/sbin`. Under Ubuntu versions > 18 this is not an issue, since `/sbin` is a link to `/usr/sbin`, but on older Ubuntu versions this simply cause `rapiddisk_sub` not to be executed at all. Now the `rapiddisk_sub` script is invoked from `/sbin` and works on old and new Ubuntu.