### PR TITLE
Buffer overflow fix in NVMe struct.

### DIFF
--- a/src/cli.h
+++ b/src/cli.h
@@ -142,7 +142,7 @@ typedef struct NVMET_PORTS {
 	int port;
 	unsigned char addr[0x1F];
 	unsigned char nqn[NAMELEN];
-	unsigned char protocol[0x5];
+	unsigned char protocol[0xF];
 	struct NVMET_PORTS *next;
 } NVMET_PORTS;
 


### PR DESCRIPTION
Buffer overflow fix in NVMe struct (https://github.com/pkoutoupis/rapiddisk/issues/90).