### PR TITLE
Fix a bug in rapiddisk-on-boot.prerm script

### DIFF
--- a/pkg/debian/rapiddisk-on-boot.prerm
+++ b/pkg/debian/rapiddisk-on-boot.prerm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 case "$1" in

--- a/pkg/debian/rapiddisk-on-boot.prerm
+++ b/pkg/debian/rapiddisk-on-boot.prerm
@@ -1,31 +1,36 @@
-#!/bin/bash
+#!/bin/sh
 
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 case "$1" in
 	remove)
-		rapiddisk-on-boot --global-uninstall
+		rapiddisk-on-boot --global-uninstall || true
 		;;
 	upgrade)
 		hooks_dir="/usr/share/initramfs-tools/hooks"
-		installations="$(for k in "$(ls /usr/share/initramfs-tools/hooks/rapiddisk_kernel* | grep -oP 'kernel_.*$' | sed 's/kernel_//')" ; do echo "$k"; done)"
-		declare -a kernel
-		declare -a size
-		declare -a device
-		declare -a cache_mode 
- 	   	
+		installations="$(for k in "$(ls 2>/dev/null /usr/share/initramfs-tools/hooks/rapiddisk_kernel* | grep -oP 'kernel_.*$' | sed 's/kernel_//')" ; do echo "$k"; done)"
 		for inst in $installations ; do
-			file="${hooks_dir:?}/rapiddisk_kernel_${inst}"
-			kernel[${#kernel[*]}]=$inst
-			size[${#size[*]}]="$(head -n 1 "$file")"
-            device[${#device[*]}]="$(head -n 2 "$file" | tail -n 1)"
-            cache_mode[${#cache_mode[*]}]="$(tail -n 1 "$file")"
+			current_file="${hooks_dir:?}/rapiddisk_kernel_${inst}"
+			file="$file ${current_file}"
+			kernel="$kernel $inst"
+			size="$size $(head -n 1 "$current_file")"
+			device="$device $(head -n 2 "$current_file" | tail -n 1)"
+			cache_mode="$cache_mode $(tail -n 1 "$current_file")"
 		done
 		if [ -f /tmp/rapiddisk-insts ] ; then
 			rm -f /tmp/rapiddisk-insts
 		fi
-		for ((i=0; i < ${#kernel[*]}; i=$i+1)) ; do
-			echo >>/tmp/rapiddisk-insts "rapiddisk-on-boot --install --kernel=${kernel[$i]} --size=${size[$i]} --cache-mode=${cache_mode[$i]} --root=${device[$i]} --force"
-		done
-		rapiddisk-on-boot --global-uninstall --no-initramfs
+		if [ -n "$inst" ] ; then
+			i=1
+			for k in $kernel ; do
+				s=$(echo $size | cut --delimiter=" " --field=$i)
+				c=$(echo $cache_mode | cut --delimiter=" " --field=$i)
+				d=$(echo $device | cut --delimiter=" " --field=$i)
+				echo >>/tmp/rapiddisk-insts "rapiddisk-on-boot --install --kernel=${k} --size=${s} --cache-mode=${c} --root=${d} --force"
+				i=$((i+1))
+			done
+		fi
+		rapiddisk-on-boot --global-uninstall --no-initramfs || true
 		;;
 esac
+exit 0
+

--- a/pkg/debian/rapiddisk-on-boot_kernel_prerm
+++ b/pkg/debian/rapiddisk-on-boot_kernel_prerm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # We're passed the version of the kernel being removed
 inst_kern=$1

--- a/scripts/rapiddisk-rootdev/ubuntu/rapiddisk_clean
+++ b/scripts/rapiddisk-rootdev/ubuntu/rapiddisk_clean
@@ -35,7 +35,11 @@ for rd in $ramdisks; do
 done
 
 for remove in $removelist ; do
-	rapiddisk 2>&1 -d $remove && log_warning_msg "rapiddisk: deleted $remove ramdisk" || log_warning_msg "rapiddisk: failed to delete $remove ramdisk"
+	if rapiddisk 2>&1 -d $remove ; then
+	  log_warning_msg "rapiddisk: deleted $remove ramdisk"
+	else
+	  log_warning_msg "rapiddisk: failed to delete $remove ramdisk"
+  fi
 done
 exit 0
 


### PR DESCRIPTION
Hello,
the `rapiddisk-on-boot.prerm` script uses `bash` arrays, but the hashbang points to `/bin/sh`. This is a **bad bug** since by default `/bin/sh` is symlinked to `/bin/dash`, a shell not supporting arrays. These leads to an error during the package update/removal which can't be resolved. I changed the hashbang to `#!/bin/bash` for that script, this should solve the issue, as long as `bash` is installed.

I changed the `rapiddisk_clean` script too, unfolding the `A && B || C` construct in an `if/then/else` one.

Regards