### PR TITLE
feat: add the '-g' flag to suppress header in rapiddisk's messages

### DIFF
--- a/doc/API.txt
+++ b/doc/API.txt
@@ -3,7 +3,7 @@ Web server API revision 1
 -------------------------
 GET /v1/checkServiceStatus
 
-ex) curl -s --output - 127.0.0.1:9118/v1/checkServiceStatus|tail -n1|jq .
+ex) curl -s --output - 127.0.0.1:9118/v1/checkServiceStatus|jq .
 
 status code: 200 (on success)
 
@@ -17,7 +17,7 @@ Check the status of the daemon. Example output:
 -------------------------
 GET /v1/listAllResources
 
-ex) curl -s --output - 127.0.0.1:9118/v1/listAllResources|tail -n1|jq .
+ex) curl -s --output - 127.0.0.1:9118/v1/listAllResources|jq .
 
 status code: 200 (on success)
 
@@ -49,7 +49,7 @@ Retrieve system resource information. Example output:
 -------------------------
 GET /v1/listRapidDiskVolumes
 
-ex) curl -s --output - 127.0.0.1:9118/v1/listRapidDiskVolumes|tail -n1|jq .
+ex) curl -s --output - 127.0.0.1:9118/v1/listRapidDiskVolumes|jq .
 
 status code: 200 (on success)
 
@@ -85,7 +85,7 @@ Retrieve rapiddisk/cache information. Example output:
 -------------------------
 POST /v1/createRapidDisk/@size
 
-ex) curl -X POST -s 127.0.0.1:9118/v1/createRapidDisk/128|tail -n1|jq .
+ex) curl -X POST -s 127.0.0.1:9118/v1/createRapidDisk/128|jq .
 
 status code: 200 (on success)
 
@@ -98,7 +98,7 @@ Create a rapiddisk volume. Example output:
 -------------------------
 POST /v1/resizeRapidDisk/@volume/@size
 
-ex) curl -X POST -s 127.0.0.1:9118/v1/resizeRapidDisk/rd0/128|tail -n1|jq .
+ex) curl -X POST -s 127.0.0.1:9118/v1/resizeRapidDisk/rd0/128|jq .
 
 status code: 200 (on success)
 
@@ -111,7 +111,7 @@ Resize an existing rapiddisk volume. Example output:
 -------------------------
 POST /v1/flushRapidDisk/@volume
 
-ex) curl -X POST -s 127.0.0.1:9118/v1/flushRapidDisk/rd0|tail -n1|jq .
+ex) curl -X POST -s 127.0.0.1:9118/v1/flushRapidDisk/rd0|jq .
 
 status code: 200 (on success)
 
@@ -124,7 +124,7 @@ Flush the memory of an existing rapiddisk volume. Example output:
 -------------------------
 POST /v1/removeRapidDisk/@volume
 
-ex) curl -X POST -s 127.0.0.1:9118/v1/removeRapidDisk/rd0|tail -n1|jq .
+ex) curl -X POST -s 127.0.0.1:9118/v1/removeRapidDisk/rd0|jq .
 
 status code: 200 (on success)
 
@@ -137,7 +137,7 @@ Remove an existing rapiddisk volume. Example output:
 -------------------------
 POST /v1/createRapidDiskCache/@volume/@source/@policy
 
-ex) curl -X POST -s 127.0.0.1:9118/v1/createRapidDiskCache/rd0/sdb/write-through|tail -n1|jq .
+ex) curl -X POST -s 127.0.0.1:9118/v1/createRapidDiskCache/rd0/sdb/write-through|jq .
 
 Supported caching policies:
 * write-through
@@ -155,7 +155,7 @@ Create a rapiddisk-cache volume. Example output:
 -------------------------
 POST /v1/removeRapidDiskCache/@volume
 
-ex) curl -X POST -s 127.0.0.1:9118/v1/removeRapidDiskCache/rc-wt_sdb|tail -n1|jq .
+ex) curl -X POST -s 127.0.0.1:9118/v1/removeRapidDiskCache/rc-wt_sdb|jq .
 
 status code: 200 (on success)
 
@@ -168,7 +168,7 @@ Remove an existing rapiddisk-cache volume. Example output:
 -------------------------
 GET /v1/showRapidDiskCacheStats/@volume
 
-ex) curl -s --output - 127.0.0.1:9118/v1/showRapidDiskCacheStats/rc-wt_sdb|tail -n1|jq .
+ex) curl -s --output - 127.0.0.1:9118/v1/showRapidDiskCacheStats/rc-wt_sdb|jq .
 
 status code: 200 (on success)
 
@@ -220,7 +220,7 @@ If it is writeback cache, it will look like this:
 -------------------------
 GET /v1/listAllNVMeTargets
 
-ex) curl -s --output - 10.0.0.185:9118/v1/listAllNVMeTargets|tail -n1|jq .
+ex) curl -s --output - 10.0.0.185:9118/v1/listAllNVMeTargets|jq .
 
 status code: 200 (on success)
 
@@ -260,7 +260,7 @@ Retrieve cache statistics from an existing rapiddisk-cache volume. Example outpu
 -------------------------
 GET /v1/listAllNVMePorts
 
-ex) curl -s --output - 10.0.0.185:9118/v1/listAllNVMePorts|tail -n1|jq .
+ex) curl -s --output - 10.0.0.185:9118/v1/listAllNVMePorts|jq .
 
 status code: 200 (on success)
 

--- a/src/net.c
+++ b/src/net.c
@@ -69,7 +69,7 @@ static int answer_to_connection(void *cls, struct MHD_Connection *connection, co
 		if (strcmp(url, CMD_PING_DAEMON) == SUCCESS) {
 			json_status_check(page);
 		} else if (strcmp(url, CMD_LIST_RESOURCES) == SUCCESS) {
-			sprintf(command, "%s/rapiddisk -q -j|tail -n1", path);
+			sprintf(command, "%s/rapiddisk -q -j -g", path);
 			stream = popen(command, "r");
 			if (stream) {
 				while (fgets(page, BUFSZ, stream) != NULL);
@@ -77,7 +77,7 @@ static int answer_to_connection(void *cls, struct MHD_Connection *connection, co
 			} else
 				status = MHD_HTTP_INTERNAL_SERVER_ERROR;
 		} else if (strcmp(url, CMD_LIST_RD_VOLUMES) == SUCCESS) {
-			sprintf(command, "%s/rapiddisk -l -j|tail -n1", path);
+			sprintf(command, "%s/rapiddisk -l -j -g", path);
 			stream = popen(command, "r");
 			if (stream) {
 				while (fgets(page, BUFSZ, stream) != NULL);
@@ -93,7 +93,7 @@ static int answer_to_connection(void *cls, struct MHD_Connection *connection, co
 				status = MHD_HTTP_BAD_REQUEST;
 				goto answer_to_connection_out;
 			}
-			sprintf(command, "%s/rapiddisk -s %s -j|tail -n1", path, token);
+			sprintf(command, "%s/rapiddisk -s %s -j -g", path, token);
 			stream = popen(command, "r");
 			if (stream) {
 				while (fgets(page, BUFSZ, stream) != NULL);
@@ -101,7 +101,7 @@ static int answer_to_connection(void *cls, struct MHD_Connection *connection, co
 			} else
 				status = MHD_HTTP_INTERNAL_SERVER_ERROR;
 		} else if (strncmp(url, CMD_LIST_NVMET, sizeof(CMD_LIST_NVMET) - 1) == SUCCESS) {
-			sprintf(command, "%s/rapiddisk -n -j|tail -n1", path);
+			sprintf(command, "%s/rapiddisk -n -j -g", path);
 			stream = popen(command, "r");
 			if (stream) {
 				while (fgets(page, BUFSZ, stream) != NULL);
@@ -109,7 +109,7 @@ static int answer_to_connection(void *cls, struct MHD_Connection *connection, co
 			} else
 				status = MHD_HTTP_INTERNAL_SERVER_ERROR;
 		} else if (strncmp(url, CMD_LIST_NVMET_PORTS, sizeof(CMD_LIST_NVMET_PORTS) - 1) == SUCCESS) {
-			sprintf(command, "%s/rapiddisk -N -j|tail -n1", path);
+			sprintf(command, "%s/rapiddisk -N -j -g", path);
 			stream = popen(command, "r");
 			if (stream) {
 				while (fgets(page, BUFSZ, stream) != NULL);
@@ -132,7 +132,7 @@ static int answer_to_connection(void *cls, struct MHD_Connection *connection, co
 				goto answer_to_connection_out;
 			}
 			size = strtoull(token, (char **)NULL, 10);
-			sprintf(command, "%s/rapiddisk -a %llu -j|tail -n1", path, size);
+			sprintf(command, "%s/rapiddisk -a %llu -j -g", path, size);
 			stream = popen(command, "r");
 			if (stream) {
 				while (fgets(page, BUFSZ, stream) != NULL);
@@ -149,7 +149,7 @@ static int answer_to_connection(void *cls, struct MHD_Connection *connection, co
 				status = MHD_HTTP_BAD_REQUEST;
 				goto answer_to_connection_out;
 			}
-			sprintf(command, "%s/rapiddisk -d %s -j|tail -n1", path, token);
+			sprintf(command, "%s/rapiddisk -d %s -j -g", path, token);
 			stream = popen(command, "r");
 			if (stream) {
 				while (fgets(page, BUFSZ, stream) != NULL);
@@ -172,7 +172,7 @@ static int answer_to_connection(void *cls, struct MHD_Connection *connection, co
 				goto answer_to_connection_out;
 			}
 			size = strtoull(token, (char **)NULL, 10);
-			sprintf(command, "%s/rapiddisk -r %s -c %llu -j|tail -n1", path, device, size);
+			sprintf(command, "%s/rapiddisk -r %s -c %llu -j -g", path, device, size);
 			stream = popen(command, "r");
 			if (stream) {
 				while (fgets(page, BUFSZ, stream) != NULL);
@@ -188,7 +188,7 @@ static int answer_to_connection(void *cls, struct MHD_Connection *connection, co
 				status = MHD_HTTP_BAD_REQUEST;
 				goto answer_to_connection_out;
 			}
-			sprintf(command, "%s/rapiddisk -f %s -j|tail -n1", path, token);
+			sprintf(command, "%s/rapiddisk -f %s -j -g", path, token);
 			stream = popen(command, "r");
 			if (stream) {
 				while (fgets(page, BUFSZ, stream) != NULL);
@@ -217,11 +217,11 @@ static int answer_to_connection(void *cls, struct MHD_Connection *connection, co
 				goto answer_to_connection_out;
 			}
 			if (strcmp(token, "write-through") == SUCCESS) {
-				sprintf(command, "%s/rapiddisk -m %s -b /dev/%s -p wt -j|tail -n1", path, device, source);
+				sprintf(command, "%s/rapiddisk -m %s -b /dev/%s -p wt -j -g", path, device, source);
 			} else if (strcmp(token, "write-around") == SUCCESS) {
-				sprintf(command, "%s/rapiddisk -m %s -b /dev/%s -p wa -j|tail -n1", path, device, source);
+				sprintf(command, "%s/rapiddisk -m %s -b /dev/%s -p wa -j -g", path, device, source);
 			} else if (strcmp(token, "writeback") == SUCCESS) {
-				sprintf(command, "%s/rapiddisk -m %s -b /dev/%s -p wb -j|tail -n1", path, device, source);
+				sprintf(command, "%s/rapiddisk -m %s -b /dev/%s -p wb -j -g", path, device, source);
 			} else {
 				status = MHD_HTTP_BAD_REQUEST;
 				goto answer_to_connection_out;
@@ -241,7 +241,7 @@ static int answer_to_connection(void *cls, struct MHD_Connection *connection, co
 				status = MHD_HTTP_BAD_REQUEST;
 				goto answer_to_connection_out;
 			}
-			sprintf(command, "%s/rapiddisk -u %s -j|tail -n1", path, token);
+			sprintf(command, "%s/rapiddisk -u %s -j -g", path, token);
 			stream = popen(command, "r");
 			if (stream) {
 				while (fgets(page, BUFSZ, stream) != NULL);

--- a/test/cache-test.sh
+++ b/test/cache-test.sh
@@ -29,7 +29,7 @@ function removeLoopbackDevices()
 
 function createCacheVolumes()
 {
-	RD=`../src/rapiddisk -a 64|tail -n1|cut -d' ' -f3`
+	RD=`../src/rapiddisk -a 64 -g|cut -d' ' -f3`
 	../src/rapiddisk -m ${RD} -b /dev/loop7
 	RETVAL=$?
 	if [ ${RETVAL} -ne 0 ]; then


### PR DESCRIPTION
This is useful when used with '-j' to provide a clean JSON output.
The examples in API.txt now use '-g' instead of '|tail -n1'.
Invocations in 'net.c' now use '-g' instead of '|tail' -n1'.