### PR TITLE
Basic .sh templates

### DIFF
--- a/scripts/ramdisk-btrfs-2gb.sh
+++ b/scripts/ramdisk-btrfs-2gb.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
+# Warning: ECC Memory recommended.
 # Btrfs = Ultra safe, but has too much Journaling = 1.7GB Free.
 # Better than NTFS, allows special characters like: ?
 # Btrfs is Unknown with very large drives: 18TB, 20TB.

--- a/scripts/ramdisk-btrfs-2gb.sh
+++ b/scripts/ramdisk-btrfs-2gb.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# For Debian: v1.01
+# Btrfs = Ultra safe, but has too much Journaling = 1.7GB Free.
+# Better than NTFS, allows special characters like: ?
+# Btrfs is Unknown with very large drives: 18TB, 20TB.
+# To execute: save and `chmod +x ./ramdisk-xfs-2gb.sh` then `./ramdisk-xfs-2gb.sh`
+
+cd ~
+sudo rapiddisk -a 2000
+sudo mkfs.btrfs -f /dev/rd0
+mkdir ramdisk
+sudo mount -t btrfs /dev/rd0 ramdisk
+sudo chown -R $(whoami):$(id -g -n) ramdisk
+
+# chown is needed because sudo creates a sudo:sudo ramdisk 
+# and $(whoami):$(id -g -n) does Not have Permissions to Write.
+# sudo is required for rapiddisk.

--- a/scripts/ramdisk-cache-btrfs-2gb.sh
+++ b/scripts/ramdisk-cache-btrfs-2gb.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# For Debian: v1.01
+# Btrfs = Ultra safe, but has too much Journaling = 1.7GB Free.
+# Better than NTFS, allows special characters like: ?
+# Btrfs is Unknown with very large drives: 18TB, 20TB.
+# you need to know what is the Btrfs drive & partition you want to add the cache.
+# EDIT sd?# BEFORE Running.
+# To execute: save and `chmod +x ./ramdisk-cache-ntfs-2gb.sh` then `./ramdisk-cache-ntfs-2gb.sh`
+
+cd ~
+# systemctl status rapiddiskd.service
+sudo rapiddisk -a 2000
+sudo mkfs.btrfs -f /dev/rd0
+mkdir ramdisk
+sudo rapiddisk -m rd0 -b /dev/sd?#
+sudo mount -t btrfs /dev/mapper/rc-wt_sd?# ramdisk

--- a/scripts/ramdisk-cache-btrfs-2gb.sh
+++ b/scripts/ramdisk-cache-btrfs-2gb.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
+# Warning: ECC Memory recommended.
 # Btrfs = Ultra safe, but has too much Journaling = 1.7GB Free.
 # Better than NTFS, allows special characters like: ?
 # Btrfs is Unknown with very large drives: 18TB, 20TB.

--- a/scripts/ramdisk-cache-ext4-2gb.sh
+++ b/scripts/ramdisk-cache-ext4-2gb.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
+# Warning: ECC Memory recommended.
 # Ext4 v2.0 is Not recomended for very large drives >2TB.
 # you need to know what is the Ext4 drive & partition you want to add the cache.
 # EDIT sd?# BEFORE Running.

--- a/scripts/ramdisk-cache-ext4-2gb.sh
+++ b/scripts/ramdisk-cache-ext4-2gb.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# For Debian: v1.01
+# Ext4 v2.0 is Not recomended for very large drives >2TB.
+# you need to know what is the Ext4 drive & partition you want to add the cache.
+# EDIT sd?# BEFORE Running.
+# To execute: save and `chmod +x ./ramdisk-cache-ntfs-2gb.sh` then `./ramdisk-cache-ntfs-2gb.sh`
+
+cd ~
+# systemctl status rapiddiskd.service
+sudo rapiddisk -a 2000
+sudo mkfs -t ext4 -F /dev/rd0
+mkdir ramdisk
+sudo rapiddisk -m rd0 -b /dev/sd?#
+sudo mount -t ext4 /dev/mapper/rc-wt_sd?# ramdisk

--- a/scripts/ramdisk-cache-hfsplus-2gb.sh
+++ b/scripts/ramdisk-cache-hfsplus-2gb.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# For Debian: v1.01
+# HFSplus Not Journaled = Faster but Not safer.
+# HFSplus does Not work with large drives >2TB.
+# Linux Free HFSplus driver is incomplete, works in OSX, but Not with Bootcamp 5 drivers in Windows.
+# Linux HFSplus cannot Name the Drive, but OSX can, and Linux detects ok.
+# you need to know what is the HFSplus drive & partition you want to add the cache.
+# EDIT sd?# BEFORE Running.
+# To execute: save and `chmod +x ./ramdisk-cache-ntfs-2gb.sh` then `./ramdisk-cache-ntfs-2gb.sh`
+
+cd ~
+# systemctl status rapiddiskd.service
+sudo rapiddisk -a 2000
+sudo mkfs.hfsplus /dev/rd0
+mkdir ramdisk
+sudo rapiddisk -m rd0 -b /dev/sd?#
+sudo mount -t hfsplus /dev/mapper/rc-wt_sd?# ramdisk

--- a/scripts/ramdisk-cache-hfsplus-2gb.sh
+++ b/scripts/ramdisk-cache-hfsplus-2gb.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
+# Warning: ECC Memory recommended.
 # HFSplus Not Journaled = Faster but Not safer.
 # HFSplus does Not work with large drives >2TB.
 # Linux Free HFSplus driver is incomplete, works in OSX, but Not with Bootcamp 5 drivers in Windows.

--- a/scripts/ramdisk-cache-hfsplus-j-2gb.sh
+++ b/scripts/ramdisk-cache-hfsplus-j-2gb.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# For Debian: v1.01
+# HFSplus Journaled.
+# HFSplus Journaled is Read Only = useless for Ramdrive.
+# consider Paragon HFSplus & APFS paid drivers for Linux is Unknown.
+# Linux Free HFSplus does Not work with large drives >2TB.
+# Linux Free HFSplus driver is incomplete, works in OSX, but Not with Bootcamp 5 drives in Windows.
+# Linux HFSplus cannot Name the Drive, but OSX can, and Linux detects ok.
+# ...
+# journaling file system keeps track of changes not yet written to the drive, 
+# pre-records the cue list of changes in a circular log known as Journal. 
+# In the event of a crash or power failure, Drive is less likely to become corrupted.
+# ...
+# you need to know what is the HFSplus drive & partition you want to add the cache.
+# EDIT sd?# BEFORE Running.
+# To execute: save and `chmod +x ./ramdisk-cache-ntfs-2gb.sh` then `./ramdisk-cache-ntfs-2gb.sh`
+
+cd ~
+# systemctl status rapiddiskd.service
+sudo rapiddisk -a 2000
+sudo mkfs.hfsplus -J /dev/rd0
+mkdir ramdisk
+sudo rapiddisk -m rd0 -b /dev/sd?#
+sudo mount -t hfsplus /dev/mapper/rc-wt_sd?# ramdisk

--- a/scripts/ramdisk-cache-hfsplus-j-2gb.sh
+++ b/scripts/ramdisk-cache-hfsplus-j-2gb.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
+# Warning: ECC Memory recommended.
 # HFSplus Journaled.
 # HFSplus Journaled is Read Only = useless for Ramdrive.
 # consider Paragon HFSplus & APFS paid drivers for Linux is Unknown.

--- a/scripts/ramdisk-cache-ntfs-2gb.sh
+++ b/scripts/ramdisk-cache-ntfs-2gb.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# For Debian: v1.01
+# sometimes a necesary evil.
+# you need to know what is the NTFS drive & partition you want to add the ram cache.
+# EDIT sd?# BEFORE Running.
+# To execute: save and `chmod +x ./ramdisk-cache-ntfs-2gb.sh` then `./ramdisk-cache-ntfs-2gb.sh`
+
+cd ~
+# systemctl status rapiddiskd.service
+sudo rapiddisk -a 2000
+sudo mkfs.ntfs -F /dev/rd0
+mkdir ramdisk
+sudo rapiddisk -m rd0 -b /dev/sd?#
+sudo mount -t ntfs /dev/mapper/rc-wt_sd?# ramdisk

--- a/scripts/ramdisk-cache-ntfs-2gb.sh
+++ b/scripts/ramdisk-cache-ntfs-2gb.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
+# Warning: ECC Memory recommended.
 # sometimes a necesary evil.
 # you need to know what is the NTFS drive & partition you want to add the ram cache.
 # EDIT sd?# BEFORE Running.

--- a/scripts/ramdisk-cache-xfs-2gb.sh
+++ b/scripts/ramdisk-cache-xfs-2gb.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
+# Warning: ECC Memory recommended.
 # To execute: save and `chmod +x ./ramdisk-cache-xfs-2gb.sh` then `./ramdisk-cache-xfs-2gb.sh`
 # you need to know what is the XFS drive & partition you want to add the cache.
 # EDIT sd?# BEFORE Running.

--- a/scripts/ramdisk-cache-xfs-2gb.sh
+++ b/scripts/ramdisk-cache-xfs-2gb.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# For Debian: v1.01
+# To execute: save and `chmod +x ./ramdisk-cache-xfs-2gb.sh` then `./ramdisk-cache-xfs-2gb.sh`
+# you need to know what is the XFS drive & partition you want to add the cache.
+# EDIT sd?# BEFORE Running.
+
+cd ~
+# systemctl status rapiddiskd.service
+sudo rapiddisk -a 2000
+sudo mkfs.xfs -f /dev/rd0
+mkdir ramdisk
+sudo rapiddisk -m rd0 -b /dev/sd?#
+sudo mount -t xfs /dev/mapper/rc-wt_sd?# ramdisk

--- a/scripts/ramdisk-ext4-2gb.sh
+++ b/scripts/ramdisk-ext4-2gb.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# For Debian: v1.01
+# Ext4 was invented in 1996 
+# since K/Ubuntu 17 there is Ext4 v2 called v1 that should be called Ext5
+# Ext4 v2 has 64-Bit Headers, Magic Number, etc...
+# Problem: Not backward compatible with older: Ext2fsd v0.69.exe, Osx MacFuse, etc...
+# R&W will damage the Ext4 v2.0 hhd or ssd, 
+# damaged hdd/sdd can be Read in Windows with Ext2fsd v0.69 but Not in Linux >20.04 LTS.
+# there is a Fork v0.70.exe but needs work.
+# to consider: Paragon Linux drivers for Windows.
+# To execute: save and `chmod +x ./ramdisk-ext4-2gb.sh` then `./ramdisk-ext4-2gb.sh`
+
+cd ~
+# systemctl start rapiddiskd.service
+sudo rapiddisk -a 2000
+sudo mkfs -t ext4 -F /dev/rd0
+mkdir ramdisk
+sudo mount -t ext4 /dev/rd0 ramdisk
+sudo chown -R $(whoami):$(id -g -n) ramdisk

--- a/scripts/ramdisk-ext4-2gb.sh
+++ b/scripts/ramdisk-ext4-2gb.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
+# Warning: ECC Memory recommended.
 # Ext4 was invented in 1996 
 # since K/Ubuntu 17 there is Ext4 v2 called v1 that should be called Ext5
 # Ext4 v2 has 64-Bit Headers, Magic Number, etc...

--- a/scripts/ramdisk-hfsplus-2gb.sh
+++ b/scripts/ramdisk-hfsplus-2gb.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# For Debian: v1.01
+# HFSplus Not Journaled = Faster but Not safer.
+# HFSplus Journaled is Read Only = useless for Ramdrive.
+# Journal is useful for drives that store information after power loss = useless for Ramdrive.
+# Linux Free HFSplus does Not work over >2TB. 
+# Better than NTFS, allows special characters like: ?
+# Paragon HFSplus & APFS paid drivers for Linux is Unknown.
+# To execute: save and `chmod +x ./ramdisk-xfs-2gb.sh` then `./ramdisk-xfs-2gb.sh`
+
+cd ~
+sudo rapiddisk -a 2000
+sudo mkfs.hfsplus -J /dev/rd0
+mkdir ramdisk
+sudo mount -t hfsplus /dev/rd0 ramdisk
+sudo chown -R $(whoami):$(id -g -n) ramdisk
+
+# chown is needed because sudo creates a sudo:sudo ramdisk 
+# and $(whoami):$(id -g -n) does Not have Permissions to Write.
+# sudo is required for rapiddisk.

--- a/scripts/ramdisk-hfsplus-2gb.sh
+++ b/scripts/ramdisk-hfsplus-2gb.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
+# Warning: ECC Memory recommended.
 # HFSplus Not Journaled = Faster but Not safer.
 # HFSplus Journaled is Read Only = useless for Ramdrive.
 # Journal is useful for drives that store information after power loss = useless for Ramdrive.

--- a/scripts/ramdisk-ntfs-2gb.sh
+++ b/scripts/ramdisk-ntfs-2gb.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
+# Warning: ECC Memory recommended.
 # NTFS driver is called NTFS-3g, Not to be confused with 2GB size. 
 # sometimes a necesary evil.
 # To execute: save and `chmod +x ./ramdisk-ntfs-2gb.sh` then `./ramdisk-ntfs-2gb.sh`

--- a/scripts/ramdisk-ntfs-2gb.sh
+++ b/scripts/ramdisk-ntfs-2gb.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# For Debian: v1.01
+# NTFS driver is called NTFS-3g, Not to be confused with 2GB size. 
+# sometimes a necesary evil.
+# To execute: save and `chmod +x ./ramdisk-ntfs-2gb.sh` then `./ramdisk-ntfs-2gb.sh`
+
+# systemctl status rapiddiskd.service 
+cd ~
+sudo rapiddisk -a 2000
+sudo mkfs.ntfs /dev/rd0
+mkdir ramdisk
+sudo mount -t ntfs /dev/rd0 ramdisk
+sudo chown -R $(whoami):$(id -g -n) ramdisk

--- a/scripts/ramdisk-off.sh
+++ b/scripts/ramdisk-off.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# For Debian: v1.01
+# To execute: save and `chmod +x ./ramdisk-detach.sh` then `./ramdisk-detach.sh`
+# Unmap & Unmount first.
+
+cd ~
+# $ sudo rapiddisk -l
+sudo rapiddisk -d rd0

--- a/scripts/ramdisk-off.sh
+++ b/scripts/ramdisk-off.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
+# Warning: ECC Memory recommended.
 # To execute: save and `chmod +x ./ramdisk-detach.sh` then `./ramdisk-detach.sh`
 # Unmap & Unmount first.
 

--- a/scripts/ramdisk-unmap.sh
+++ b/scripts/ramdisk-unmap.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
+# Warning: ECC Memory recommended.
 # To execute: save and `chmod +x ./ramdisk-unmap.sh` then `./ramdisk-unamp.sh`
 # you need to know what is the Mapped cache drive.
 # EDIT sd?# BEFORE Running.

--- a/scripts/ramdisk-unmap.sh
+++ b/scripts/ramdisk-unmap.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# For Debian: v1.01
+# To execute: save and `chmod +x ./ramdisk-unmap.sh` then `./ramdisk-unamp.sh`
+# you need to know what is the Mapped cache drive.
+# EDIT sd?# BEFORE Running.
+
+cd ~
+# $ sudo rapiddisk -l
+# $ sudo rapiddisk -s
+sudo rapiddisk -u rc-wt_sd?#
+# $ sudo rapiddisk -d rd0

--- a/scripts/ramdisk-xfs-2gb.sh
+++ b/scripts/ramdisk-xfs-2gb.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# For Debian: v1.01
+# XFS is the Only FileSystem that works ok with VeryLargeDrives: 18TB, 20TB.
+# forget Ext4 over >2TB, makes weird noises, can damage mechanical drives.
+# Linux Free HFSplus, better than NTFS, but does Not work over >2TB.
+# forget Linux Free HFSplus Journaled. 
+# Paragon HFSplus & APFS paid drivers for Linux is Unknown.
+# forget NTFS-3g, files & folders cannot have special characters like: ?
+# forget exFAT, FAT32, FAT16, etc... worse than NTFS.
+# Btrfs = Ultra safe, but has too much Journaling = 1.7GB Free of 2GB, allows special characters like: ?
+# Btrfs is Unknown with very large drives: 18TB, 20TB.
+# Cifs = smbfs: Unknown.
+# To execute: save and `chmod +x ./ramdisk-xfs-2gb.sh` then `./ramdisk-xfs-2gb.sh`
+
+cd ~
+sudo rapiddisk -a 2000
+sudo mkfs.xfs -f /dev/rd0
+mkdir ramdisk
+sudo mount -t xfs /dev/rd0 ramdisk
+sudo chown -R $(whoami):$(id -g -n) ramdisk
+
+# chown is needed because sudo creates a sudo:sudo ramdisk 
+# and $(whoami):$(id -g -n) does Not have Permissions to Write.
+# sudo is required for rapiddisk.

--- a/scripts/ramdisk-xfs-2gb.sh
+++ b/scripts/ramdisk-xfs-2gb.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
+# Warning: ECC Memory recommended.
 # XFS is the Only FileSystem that works ok with VeryLargeDrives: 18TB, 20TB.
 # forget Ext4 over >2TB, makes weird noises, can damage mechanical drives.
 # Linux Free HFSplus, better than NTFS, but does Not work over >2TB.

--- a/scripts/reinstall-rapiddisk-a.sh
+++ b/scripts/reinstall-rapiddisk-a.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# For Debian: v1.01
+# Reinstall script Part1/3 for Rapiddisk 8.2.0 Linux.
+# Everytime there is a Kernet change, Rapiddisk needs to be reinstalled.
+# To execute: save and `chmod +x ./reinstall-rapiddisk-a.sh` then `./reinstall-rapiddisk-a.sh`
+
+sudo systemctl stop rapiddisk.service
+sudo systemctl disable rapiddisk.service
+sudo modprobe -r rapiddisk
+sudo modprobe -r rapiddisk-cache
+whereis rapiddisk
+# rapiddisk: /usr/sbin/rapiddisk /etc/rapiddisk /usr/share/man/man1/rapiddisk.1
+sudo rm /usr/sbin/rapiddisk
+sudo rm /etc/rapiddisk
+sudo rm /usr/share/man/man1/rapiddisk.1
+sudo systemctl daemon-reload
+sudo systemctl reset-failed
+sudo make uninstall
+sudo reboot 10

--- a/scripts/reinstall-rapiddisk-a.sh
+++ b/scripts/reinstall-rapiddisk-a.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
-# Reinstall script Part1/3 for Rapiddisk 8.2.0 Linux.
+# Reinstall script Part 1/3 for Rapiddisk 8.2.0 Linux.
 # Everytime there is a Kernet change, Rapiddisk needs to be reinstalled.
 # To execute: save and `chmod +x ./reinstall-rapiddisk-a.sh` then `./reinstall-rapiddisk-a.sh`
 

--- a/scripts/reinstall-rapiddisk-a.sh
+++ b/scripts/reinstall-rapiddisk-a.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
+# Warning: ECC Memory recommended.
 # Reinstall script Part 1/3 for Rapiddisk 8.2.0 Linux.
 # Everytime there is a Kernet change, Rapiddisk needs to be reinstalled.
 # To execute: save and `chmod +x ./reinstall-rapiddisk-a.sh` then `./reinstall-rapiddisk-a.sh`

--- a/scripts/reinstall-rapiddisk-b.sh
+++ b/scripts/reinstall-rapiddisk-b.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# For Debian: v1.01
+# Reinstall Part2/3 for Rapiddisk 8.2.0 Linux.
+# Everytime there is a Kernet change, Rapiddisk needs to be reinstalled.
+# To execute: save and `chmod +x ./reinstall-rapiddisk-b.sh` then `./reinstall-rapiddisk-b.sh`
+
+make
+sudo make install
+sudo reboot 10

--- a/scripts/reinstall-rapiddisk-b.sh
+++ b/scripts/reinstall-rapiddisk-b.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
+# Warning: ECC Memory recommended.
 # Reinstall Part 2/3 for Rapiddisk 8.2.0 Linux.
 # Everytime there is a Kernet change, Rapiddisk needs to be reinstalled.
 # To execute: save and `chmod +x ./reinstall-rapiddisk-b.sh` then `./reinstall-rapiddisk-b.sh`

--- a/scripts/reinstall-rapiddisk-b.sh
+++ b/scripts/reinstall-rapiddisk-b.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
-# Reinstall Part2/3 for Rapiddisk 8.2.0 Linux.
+# Reinstall Part 2/3 for Rapiddisk 8.2.0 Linux.
 # Everytime there is a Kernet change, Rapiddisk needs to be reinstalled.
 # To execute: save and `chmod +x ./reinstall-rapiddisk-b.sh` then `./reinstall-rapiddisk-b.sh`
 

--- a/scripts/reinstall-rapiddisk-c.sh
+++ b/scripts/reinstall-rapiddisk-c.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
+# Warning: ECC Memory recommended.
 # Reinstall Part 3/3 for Rapiddisk 8.2.0 Linux.
 # Everytime there is a Kernet change, Rapiddisk needs to be reinstalled.
 # To execute: save and `chmod +x ./reinstall-linux-c.sh` then `./reinstall-rapiddisk-c.sh`

--- a/scripts/reinstall-rapiddisk-c.sh
+++ b/scripts/reinstall-rapiddisk-c.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# For Debian: v1.01
+# Reinstall Part3/3 for Rapiddisk 8.2.0 Linux.
+# Everytime there is a Kernet change, Rapiddisk needs to be reinstalled.
+# To execute: save and `chmod +x ./reinstall-linux-c.sh` then `./reinstall-rapiddisk-c.sh`
+
+# modprobe rapiddisk
+# modprobe rapiddisk-cache
+
+# make tools-install
+# make tools-uninstall
+
+# make dkms-install
+# make dkms-uninstall
+
+systemctl enable rapiddiskd.service
+# systemctl status rapiddiskd.service

--- a/scripts/reinstall-rapiddisk-c.sh
+++ b/scripts/reinstall-rapiddisk-c.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
-# Reinstall Part3/3 for Rapiddisk 8.2.0 Linux.
+# Reinstall Part 3/3 for Rapiddisk 8.2.0 Linux.
 # Everytime there is a Kernet change, Rapiddisk needs to be reinstalled.
 # To execute: save and `chmod +x ./reinstall-linux-c.sh` then `./reinstall-rapiddisk-c.sh`
 

--- a/scripts/uninstall-rapiddisk.sh
+++ b/scripts/uninstall-rapiddisk.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # For Debian: v1.01
+# Warning: ECC Memory recommended.
 # Uninstall script for Rapiddisk 8.2.0 Linux.
 # To execute: save and `chmod +x ./uninstall-linux.sh` then `./uninstall-rapiddisk.sh`
 

--- a/scripts/uninstall-rapiddisk.sh
+++ b/scripts/uninstall-rapiddisk.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# For Debian: v1.01
+# Uninstall script for Rapiddisk 8.2.0 Linux.
+# To execute: save and `chmod +x ./uninstall-linux.sh` then `./uninstall-rapiddisk.sh`
+
+sudo systemctl stop rapiddisk.service
+sudo systemctl disable rapiddisk.service
+sudo modprobe -r rapiddisk
+sudo modprobe -r rapiddisk-cache
+whereis rapiddisk
+# rapiddisk: /usr/sbin/rapiddisk /etc/rapiddisk /usr/share/man/man1/rapiddisk.1
+sudo rm /usr/sbin/rapiddisk
+sudo rm /etc/rapiddisk
+sudo rm /usr/share/man/man1/rapiddisk.1
+sudo systemctl daemon-reload
+sudo systemctl reset-failed
+sudo make uninstall
+
+sudo reboot 10


### PR DESCRIPTION
those .sh could be better, but v1.01 are "get the job done" version. LOL.™

The reason i dont put those in the /examples folder 
is because time saving...
most .sh work right away.

the idea of the scripts is time saving...
Nested inside more directories, will force many people to cut & paste to other place.
making people waste time.
the idea is: 
instant gratification. LOL.™
snapping fingers & increase speed. LOL.™

P.D. important for people using very large external hdd's on Debian:
https://github.com/juanpc2018/-SOLVED-Very-Large-HDD-on-Linux-USB3.0-mass-storage-Problem

also Not having ECC memory...
