### PR TITLE
Fix missing check for port when exporting/unexporting (NVMe)

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -90,6 +90,7 @@ typedef char bool;
 #define ERR_SIGPIPE_HANDLER	"Failed to install SIGPIPE handler: %s, %s"
 #define ERR_INVALID_MODE	"Invalid cache mode in URL."
 #define ERR_DEV_NOEXIST		"Error. Device %s does not exist."
+#define ERR_PORT_NOEXIST		"Error. Port %d does not exist."
 #define ERR_CACHE_TGT_NOEXIST	"Error. Cache target %s does not exist."
 
 /**


### PR DESCRIPTION
Add a new #define for an error message in common.h. Use scandir_filter_no_dot() filter for scandir() more often.

This is related to an issue in PR #145, as described [here](https://github.com/pkoutoupis/rapiddisk/pull/145#issuecomment-1379388352).