### PR TITLE
Remove absolute path from service file

### DIFF
--- a/conf/rapiddiskd.service
+++ b/conf/rapiddiskd.service
@@ -3,7 +3,7 @@ Description=A rapiddisk network management daemon
 After=network.target
 
 [Service]
-ExecStartPre=/usr/bin/sh -c 'lsmod | grep -q rapiddisk || { modprobe rapiddisk ; modprobe rapiddisk-cache ; }'
+ExecStartPre=sh -c 'lsmod | grep -q rapiddisk || { modprobe rapiddisk ; modprobe rapiddisk-cache ; }'
 ExecStart=/sbin/rapiddiskd
 Type=forking
 Restart=always


### PR DESCRIPTION
`ExecstartPre` in `rapiddiskd.service` uses an absolute path to `sh`, `/usr/bin/`, but on some system `sh` is placed in `/bin/`. This causes the service to fail upon start. Removing the absolute path seems to solve.

Fix #156 