### PR TITLE
Fix some nvmet_unexport_volume() issues and improve NVMET_PROFILE struct

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -202,6 +202,7 @@ typedef struct NVMET_PROFILE {
 	char device[0x1F];
 	int enabled;
 	struct NVMET_ALLOWED_HOST *allowed_hosts;
+	struct NVMET_PORTS *assigned_ports;
 	struct NVMET_PROFILE *next;
 } NVMET_PROFILE;
 

--- a/src/common.h
+++ b/src/common.h
@@ -201,6 +201,7 @@ typedef struct NVMET_PROFILE {
 	int namespc;
 	char device[0x1F];
 	int enabled;
+	struct NVMET_ALLOWED_HOST *allowed_hosts;
 	struct NVMET_PROFILE *next;
 } NVMET_PROFILE;
 
@@ -216,5 +217,10 @@ typedef struct DAEMON_ARGS {
 	bool verbose;
 	char port[0xf];
 } DAEMON_ARGS;
+
+typedef struct NVMET_ALLOWED_HOST { ;
+	char allowed_host[NAMELEN];
+	struct NVMET_ALLOWED_HOST *next;
+} NVMET_ALLOWED_HOST;
 
 #endif

--- a/src/json.c
+++ b/src/json.c
@@ -488,20 +488,22 @@ int json_cache_wb_statistics(struct WC_STATS *stats, char **stats_result, bool w
  */
 
 /**
- * It takes a linked list of NVMET_PROFILE and NVMET_PORTS structures and converts them to JSON
+ * It takes a linked list of NVMET_PROFILE structures and converts them to JSON
  *
  * @param nvmet A pointer to the first element of the linked list of NVMET_PROFILE structures.
- * @param ports A pointer to the first element of the linked list of NVMET_PORTS structures.
  * @param json_result This is a pointer to a pointer to a char.  It's used to return the JSON string to the caller.
  * @param wantresult If TRUE, the function will place the pointer to the JSON string into *stats_result (must be free()d later).
  * If FALSE, the JSON string will be printed to stdout.
  *
  * @return A JSON string containing the NVMET targets and ports.
  */
-int json_nvmet_view_exports(struct NVMET_PROFILE *nvmet, struct NVMET_PORTS *ports, char **json_result, bool wantresult)
+int json_nvmet_view_exports(struct NVMET_PROFILE *nvmet, char **json_result, bool wantresult)
 {
 	json_t *root, *array = json_array(), *nvmet_array = json_array(), *ports_array = json_array();
 	json_t *nvmet_object = json_object(), *ports_object = json_object();
+	NVMET_PROFILE *nvmet_orig = nvmet;
+	NVMET_PORTS *ports;
+	NVMET_ALLOWED_HOST *allowed_hosts;
 	int res = SUCCESS;
 
 	while (nvmet != NULL) {
@@ -510,21 +512,51 @@ int json_nvmet_view_exports(struct NVMET_PROFILE *nvmet, struct NVMET_PORTS *por
 		json_object_set_new(object, "namespace", json_integer(nvmet->namespc));
 		json_object_set_new(object, "device", json_string(nvmet->device));
 		json_object_set_new(object, "enabled", json_string((nvmet->enabled == ENABLED) ? "true" : "false"));
+		json_t *hosts_allowed_array = json_array();
+		allowed_hosts = nvmet->allowed_hosts;
+		while (allowed_hosts != NULL) {
+			json_t *object_h = json_object();
+			json_object_set_new(object_h, "host", json_string(allowed_hosts->allowed_host));
+			json_array_append_new(hosts_allowed_array, object_h);
+			allowed_hosts = allowed_hosts->next;
+		}
+		json_object_set_new(object, "allowed_hosts", hosts_allowed_array);
+
+		json_t *assigned_ports_array = json_array();
+		ports = nvmet->assigned_ports;
+		while (ports != NULL) {
+			json_t *object_p = json_object();
+			json_object_set_new(object_p, "port", json_integer(ports->port));
+			json_object_set_new(object_p, "address", json_string(ports->addr));
+			json_object_set_new(object_p, "protocol", json_string(ports->protocol));
+			json_object_set_new(object_p, "nqn", json_string(ports->nqn));
+			json_array_append_new(assigned_ports_array, object_p);
+			ports = ports->next;
+		}
+		json_object_set_new(object, "assigned_ports", assigned_ports_array);
+
 		json_array_append_new(nvmet_array, object);
 		nvmet = nvmet->next;
 	}
 	json_object_set_new(nvmet_object, "nvmet_targets", nvmet_array);
 	json_array_append_new(array, nvmet_object);
 
-	while (ports != NULL) {
-		json_t *object = json_object();
-		json_object_set_new(object, "port", json_integer(ports->port));
-		json_object_set_new(object, "address", json_string(ports->addr));
-		json_object_set_new(object, "protocol", json_string(ports->protocol));
-		json_object_set_new(object, "nqn", json_string(ports->nqn));
-		json_array_append_new(ports_array, object);
-		ports = ports->next;
+	nvmet = nvmet_orig;
+
+	while (nvmet != NULL) {
+		ports = nvmet->assigned_ports;
+		while (ports != NULL) {
+			json_t *object_pp = json_object();
+			json_object_set_new(object_pp, "port", json_integer(ports->port));
+			json_object_set_new(object_pp, "address", json_string(ports->addr));
+			json_object_set_new(object_pp, "protocol", json_string(ports->protocol));
+			json_object_set_new(object_pp, "nqn", json_string(ports->nqn));
+			json_array_append_new(ports_array, object_pp);
+			ports = ports->next;
+		}
+		nvmet = nvmet->next;
 	}
+
 	json_object_set_new(ports_object, "nvmet_ports", ports_array);
 	json_array_append_new(array, ports_object);
 

--- a/src/json.h
+++ b/src/json.h
@@ -40,7 +40,7 @@ int json_resources_list(struct MEM_PROFILE *mem, struct VOLUME_PROFILE *volume, 
 int json_cache_statistics(struct RC_STATS *stats, char **stats_result, bool wantresult);
 int json_cache_wb_statistics(struct WC_STATS *stats, char **stats_result, bool wantresult);
 int json_status_return(int return_value, char *optional_message, char **json_result, bool wantresult);
-int json_nvmet_view_exports(struct NVMET_PROFILE *nvmet, struct NVMET_PORTS *ports, char **json_result, bool wantresult);
+int json_nvmet_view_exports(struct NVMET_PROFILE *nvmet, char **json_result, bool wantresult);
 int json_nvmet_view_ports(struct NVMET_PORTS *ports, char **json_result, bool wantresult);
 #ifdef SERVER
 int json_status_check(char **json_str);

--- a/src/utils.c
+++ b/src/utils.c
@@ -152,9 +152,31 @@ void clean_ports(NVMET_PORTS *head) {
 	}
 }
 
+void clean_hosts(NVMET_ALLOWED_HOST *head) {
+	/* if there is only one item in the list, remove it */
+	if (head->next == NULL) {
+		if (head != NULL) free(head);
+		head = NULL;
+	} else {
+		/* get to the second to last node in the list */
+		struct NVMET_ALLOWED_HOST *current = head;
+		while (current->next->next != NULL) {
+			current = current->next;
+		}
+
+		/* now current points to the second to last item of the list, so let's remove current->next */
+		if (current->next != NULL) {
+			free(current->next);
+			current->next = NULL;
+		}
+		clean_hosts(head);
+	}
+}
+
 void clean_nvmet(NVMET_PROFILE *head) {
 	/* if there is only one item in the list, remove it */
 	if (head->next == NULL) {
+		if (head->allowed_hosts != NULL && head->allowed_hosts->next == NULL) free(head->allowed_hosts);
 		if (head != NULL) free(head);
 		head = NULL;
 	} else {
@@ -163,7 +185,9 @@ void clean_nvmet(NVMET_PROFILE *head) {
 		while (current->next->next != NULL) {
 			current = current->next;
 		}
-
+		if (current->next->allowed_hosts != NULL) {
+			clean_hosts(current->next->allowed_hosts);
+		}
 		/* now current points to the second to last item of the list, so let's remove current->next */
 		if (current->next != NULL) {
 			free(current->next);

--- a/src/utils.c
+++ b/src/utils.c
@@ -176,7 +176,14 @@ void clean_hosts(NVMET_ALLOWED_HOST *head) {
 void clean_nvmet(NVMET_PROFILE *head) {
 	/* if there is only one item in the list, remove it */
 	if (head->next == NULL) {
-		if (head->allowed_hosts != NULL && head->allowed_hosts->next == NULL) free(head->allowed_hosts);
+		if (head->allowed_hosts != NULL) {
+			clean_hosts(head->allowed_hosts);
+			head->allowed_hosts = NULL;
+		}
+		if (head->assigned_ports != NULL) {
+			clean_ports(head->assigned_ports);
+			head->assigned_ports = NULL;
+		}
 		if (head != NULL) free(head);
 		head = NULL;
 	} else {
@@ -187,6 +194,11 @@ void clean_nvmet(NVMET_PROFILE *head) {
 		}
 		if (current->next->allowed_hosts != NULL) {
 			clean_hosts(current->next->allowed_hosts);
+			current->next->allowed_hosts = NULL;
+		}
+		if (current->next->assigned_ports != NULL) {
+			clean_ports(current->next->assigned_ports);
+			current->next->assigned_ports = NULL;
 		}
 		/* now current points to the second to last item of the list, so let's remove current->next */
 		if (current->next != NULL) {


### PR DESCRIPTION
1. Add the `NVMET_ALLOWED_HOST` struct and put it inside `NVMET_PROFILE`, so that for every NQN there is a corresponding linked list of the hosts which was granted the access.
2. Now `nvmet_scan_subsystem()` fills and adds the allowed hosts in `NVMET_ALLOWED_HOST` to every `NVMET_PROFILE`.
3. Now `nvmet_view_exports()`, in normal - not JSON - mode, prints all the hosts allowed to access each NQN.
4. `nvmet_unexport_volume()` does not delete host dir from `/sys/kernel/config/nvmet/hosts/` if there are other NQN using that dir.
5. `free_nvmet_linked_lists()` now frees the memory allocated for the `NVMET_ALLOWED_HOST` linked lists too.