### PR TITLE
Fix 'pkg/debian/changelog' and 'pkg/debian/control'

### DIFF
--- a/pkg/debian/changelog
+++ b/pkg/debian/changelog
@@ -1,17 +1,27 @@
 rapiddisk (9.1.0-1) UNRELEASED; urgency=medium
 
+  [Petros Koutoupis]
   * module: Fixed large performance regression bug with resize mutex.
   * module: Added RHEL 9 support.
   * module: Added support for new ioctls.
   * module: Fixed GFP_HIGHMEM page allocation bug.
   * utility: Added NVMe Target loopback support.
   * utility: Fixed issue #155 with strlen of NULL string segfault.
-  * utility: Reworked nvmet exports, unexports and port scanning logic (thank you Matteo Tenca).
+  * utility: Reworked nvmet exports, unexports and port scanning logic (thank
+    you Matteo Tenca).
   * scripts: Added example BCC tools script.
   * documentation: Added RPM building documentation.
 
+  [Matteo Tenca]
+  * New upstream release.
+  * Changed Build-Depends to adapt to the new dependency relations between 'dkms' and 'dh_dkms'
+    starting with Ubuntu 22.10 Kinetic.
+
+ -- Matteo Tenca <matteo.tenca@gmail.com>  Mon, 28 Apr 2023 00:00:00 +0000
+
 rapiddisk (9.0.0-1) UNRELEASED; urgency=medium
 
+  [Petros Koutoupis]
   * module: Added code to capture page count metrics.
   * module: Updated ioctl support.
   * module: Fixed page alloc usage decrement on discard.
@@ -37,7 +47,10 @@ rapiddisk (9.0.0-1) UNRELEASED; urgency=medium
   * documentation: Added contrib file and cleaned up README and man pages.
   * documentation: Added doxygen documentation support (thank you Matteo Tenca).
 
- -- Petros Koutoupis <petros@petroskoutoupis.com>  Wed, 28 Dec 2022 08:56:52 +0000
+  [Matteo Tenca]
+  * New upstream release.
+
+ -- Matteo Tenca <matteo.tenca@gmail.com>  Wed, 28 Dec 2022 08:56:52 +0000
 
 rapiddisk (8.2.0-1) UNRELEASED; urgency=medium
 

--- a/pkg/debian/control
+++ b/pkg/debian/control
@@ -1,9 +1,11 @@
 Source: rapiddisk
 Section: misc
 Priority: optional
-Maintainer: Petros Koutoupis <petros@petroskoutoupis.com>
-Build-Depends: debhelper, dkms, libjansson4, libmicrohttpd12, libjansson-dev, libmicrohttpd-dev, libpcre2-8-0, libpcre2-dev, libdevmapper1.02.1, libdevmapper-dev
+Maintainer: Matteo Tenca <matteo.tenca@gmail.com>
+Build-Depends: debhelper, dh-dkms | dh-sequence-dkms | dkms, libjansson-dev, libmicrohttpd-dev, libpcre2-dev, libdevmapper-dev
 Homepage: https://github.com/pkoutoupis/rapiddisk/
+Vcs-Browser: https://github.com/pkoutoupis/rapiddisk/
+Vcs-Git: https://github.com/pkoutoupis/rapiddisk.git
 Standards-Version: 4.4.1
 
 Package: rapiddisk

--- a/src/nvmet.h
+++ b/src/nvmet.h
@@ -43,6 +43,7 @@ struct NVMET_PROFILE *nvmet_scan_subsystem(char *return_message, int *rc);
 struct NVMET_PORTS *nvmet_scan_ports(char *return_message, int *rc);
 struct NVMET_PORTS *nvmet_scan_all_ports(char *return_message, int *rc);
 char *nvmet_interface_ip_get(char *interface, char *return_message);
+bool check_nvmet_subsystem(char *return_message);
 #ifndef SERVER
 int nvmet_view_exports(bool json_flag, char *error_message);
 int nvmet_view_ports(bool json_flag, char *error_message);


### PR DESCRIPTION
1. Changed `Build-Depends` in `control` to adapt to the new dependency's relations between `dkms` and `dh-dkms` starting with Ubuntu 22.10 Kinetic.
2. Fixed the `changelog`.
3. Added `check_nvmet_subsystem()` function to verify whether the NVMe kernel modules were loaded.