### PR TITLE
Feature/add new rhel9 kernel support

### DIFF
--- a/module/rapiddisk-cache.c
+++ b/module/rapiddisk-cache.c
@@ -178,8 +178,13 @@ int dm_io_async_bvec(unsigned int num_regions, struct dm_io_region *where,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,0)
 	(rw == WRITE) ? (iorq.bi_opf = REQ_OP_WRITE) : (iorq.bi_opf = REQ_OP_READ);
 #else
+//#if (defined(RHEL_MAJOR) && RHEL_MAJOR >= 9 && RHEL_MINOR >= 2)
+#if (defined(RHEL_MAJOR) && RHEL_MAJOR >= 9)
+	iorq.bi_opf = rw;
+#else
 	iorq.bi_op = rw;
 	iorq.bi_op_flags = 0;
+#endif
 #endif
 #else
 	iorq.bi_rw = rw;

--- a/module/rapiddisk-cache.c
+++ b/module/rapiddisk-cache.c
@@ -178,8 +178,7 @@ int dm_io_async_bvec(unsigned int num_regions, struct dm_io_region *where,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,0)
 	(rw == WRITE) ? (iorq.bi_opf = REQ_OP_WRITE) : (iorq.bi_opf = REQ_OP_READ);
 #else
-//#if (defined(RHEL_MAJOR) && RHEL_MAJOR >= 9 && RHEL_MINOR >= 2)
-#if (defined(RHEL_MAJOR) && RHEL_MAJOR >= 9)
+#if (defined(RHEL_MAJOR) && RHEL_MAJOR >= 9 && RHEL_MINOR >= 2)
 	iorq.bi_opf = rw;
 #else
 	iorq.bi_op = rw;

--- a/module/rapiddisk.c
+++ b/module/rapiddisk.c
@@ -75,7 +75,7 @@ static DEFINE_MUTEX(ioctl_mutex);
 
 struct rdsk_device {
 	int num;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,15,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,14,0)
 	struct request_queue *rdsk_queue;
 #endif
 	struct gendisk *rdsk_disk;
@@ -928,7 +928,7 @@ static int detach_device(unsigned long num)
 	list_del(&rdsk->rdsk_list);
 	del_gendisk(rdsk->rdsk_disk);
 	put_disk(rdsk->rdsk_disk);
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,15,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,14,0)
 	blk_cleanup_queue(rdsk->rdsk_queue);
 #endif
 	rdsk_free_pages(rdsk);


### PR DESCRIPTION
Add support for RHEL 9.2+ kernels and above (covers CentOS Stream 9).