### PR TITLE
Allow human-readable notation for sizes in command line (B/KB/KiB) etc.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -36,8 +36,8 @@ else
 NDEBUG_CFLAGS := -O2 -Wno-unused-result -flto=auto -ffat-lto-objects -fstack-protector-strong $(CFLAGS)
 endif
 ifndef LDLIBS
-COMMON_LDLIBS := -ljansson -ldevmapper -lpcre2-8
-DAEMON_LDLIBS := -ljansson -ldevmapper -lpcre2-8 -lmicrohttpd
+COMMON_LDLIBS := -ljansson -ldevmapper -lpcre2-8 -lm
+DAEMON_LDLIBS := -ljansson -ldevmapper -lpcre2-8 -lmicrohttpd -lm
 else
 COMMON_LDLIBS := $(LDLIBS)
 DAEMON_LDLIBS := $(LDLIBS)

--- a/src/common.h
+++ b/src/common.h
@@ -43,6 +43,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <unistd.h>
 #include <dirent.h>
 #include <stddef.h>
+#include <math.h>
 
 /** Rapiddisk Process name */
 #define PROCESS			"rapiddisk"

--- a/src/utils.h
+++ b/src/utils.h
@@ -43,5 +43,5 @@ struct dirent **clean_scandir(struct dirent **scanlist, int num);
 int check_loaded_modules(void);
 void print_message(int ret_value, char *message, bool json_flag);
 char *verbose_msg(char *dest, char *msg);
-
+unsigned long long int validate_size(const char *re, char *subject, char *error_message);
 #endif //UTILS_H


### PR DESCRIPTION
As per feature request #176, now it is possible to specify a number followed by B/KiB/KB/MiB/MB/GiB/GB. If the specified size will result in a value < 1048576 Bytes, an error will be raised.