### PR TITLE
Linux 6.9 support

### DIFF
--- a/module/rapiddisk.c
+++ b/module/rapiddisk.c
@@ -807,12 +807,18 @@ static int attach_device(unsigned long num, unsigned long long size)
 	blk_queue_make_request(rdsk->rdsk_queue, rdsk_make_request);
 #endif
 #endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0)
+	disk = rdsk->rdsk_disk = blk_alloc_disk(NULL, NUMA_NO_NODE);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
 	disk = rdsk->rdsk_disk = blk_alloc_disk(NUMA_NO_NODE);
 #else
 	disk = rdsk->rdsk_disk = alloc_disk(1);
 #endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0)
+	if (IS_ERR(disk))
+#else
 	if (!disk)
+#endif
 		goto out_free_queue;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
 	blk_queue_logical_block_size(disk->queue, BYTES_PER_SECTOR);

--- a/module/rapiddisk.c
+++ b/module/rapiddisk.c
@@ -815,13 +815,6 @@ static int attach_device(unsigned long num, unsigned long long size)
 	if (!disk)
 		goto out_free_queue;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
-	disk = rdsk->rdsk_disk = blk_alloc_disk(NUMA_NO_NODE);
-#else
-	disk = rdsk->rdsk_disk = alloc_disk(1);
-#endif
-	if (!disk)
-		goto out_free_queue;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
 	blk_queue_logical_block_size(disk->queue, BYTES_PER_SECTOR);
 	blk_queue_physical_block_size(disk->queue, PAGE_SIZE);
 #else


### PR DESCRIPTION
The duplicate allocation (probably a copy+paste error when moving around the code) is a potential memory leak.

Add another case for the new two-argument `blk_alloc_disk()`. Adjust the error handling as well, since it now returns an `errno` as `ERR_PTR()` instead of `NULL` in case of error.

Not tested beyond module compilation.